### PR TITLE
Adding example for php extensions in docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@
 cd your_drupal_project
 docker run --rm -v `pwd`:`pwd` -w `pwd` skilldlabs/docker-drupal-check:last drupal-check -ad -vv -n --no-progress web/modules/custom/
 ```
+
+## Adding php extensions
+
+```
+docker run --rm -v `pwd`:`pwd` -w `pwd` skilldlabs/docker-drupal-check:last sh -c "apk add php7-soap && drupal-check -ad -vv -n --no-progress web/modules/custom/"
+```


### PR DESCRIPTION
Related to issue https://github.com/skilld-labs/docker-drupal-check/issues/4